### PR TITLE
Add adgroup property

### DIFF
--- a/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
+++ b/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
@@ -187,11 +187,12 @@ extension AppsFlyerDestination: AppsFlyerLibDelegate {
         
         if (firstLaunchFlag == 1) {
             if (status == "Non-organic") {
-                if let mediaSource = conversionInfo["media_source"] , let campaign = conversionInfo["campaign"]{
+                if let mediaSource = conversionInfo["media_source"] , let campaign = conversionInfo["campaign"], let adgroup = conversionInfo["adgroup"]{
                     
                     let campaign: [String: Any] = [
                         "source": mediaSource,
-                        "name": campaign
+                        "name": campaign,
+                        "ad_group": adgroup
                     ]
                     let campaignStr = (campaign.compactMap({ (key, value) -> String in
                         return "\(key)=\(value)"


### PR DESCRIPTION
To match the functionality of our old iOS SDK, we should be collecting the Adgroup property. https://github.com/AppsFlyerSDK/segment-appsflyer-ios/blob/master/segment-appsflyer-ios/Classes/SEGAppsFlyerIntegration.m#L242C85-L242C92