### PR TITLE
Fix campaign data

### DIFF
--- a/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
+++ b/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
@@ -213,12 +213,10 @@ extension AppsFlyerDestination: AppsFlyerLibDelegate {
                         "name": campaign,
                         "ad_group": adgroup
                     ]
-                    let campaignStr = (campaign.compactMap({ (key, value) -> String in
-                        return "\(key)=\(value)"
-                    }) as Array).joined(separator: ";")
+
                     let properties: [String: Codable] = [
                         "provider": "AppsFlyer",
-                        "campaign": campaignStr
+                        "campaign": try? JSON(campaign)
                     ]
                     analytics?.track(name: "Install Attributed", properties: properties)
                     


### PR DESCRIPTION
The previous change set the campaign data to a string like so:
`   
 "campaign": "source=test1;name=test2;ad_group=<null>",
`

We wish to set this as an object instead:
`
[[SEGAnalytics sharedAnalytics] track:@"Install Attributed", properties: @{
    @"provider" : @"Appsflyer/Tune/Kochava/Branch",
    @"campaign" : @{
        @"source" : @"Network/FB/AdWords/MoPub/Source",
        @"name" : @"Campaign Name",
        @"content" : @"Organic Content Title",
        @"ad_creative" : @"Red Hello World Ad",
        @"ad_group" : @"Red Ones",
        @"conversion_date": @"2018-03-07T04:05:50Z",
        @"id": @"123",
        @"ad_group_id": @"456",
        @"click_date": @"2018-03-06T04:05:50Z",
        @"lineitem_id":@"789",
        @"attribution":@"true",
        @"lineitem_name":@"US-iOS-campaign-Name"
    }
}];
`