### PR TITLE
Enhancements to Segment Plugin for AppsFlyer SDK Integration

### DIFF
--- a/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
+++ b/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
@@ -215,17 +215,17 @@ extension AppsFlyerDestination {
 
 extension AppsFlyerDestination: AppsFlyerLibDelegate {
     public func onConversionDataSuccess(_ conversionInfo: [AnyHashable : Any]) {
-        // guard let firstLaunchFlag = conversionInfo["is_first_launch"] as? Int else {
-        //     return
-        // }
+        guard let firstLaunchFlag = conversionInfo["is_first_launch"] as? Int else {
+            return
+        }
         
-        // guard let status = conversionInfo["af_status"] as? String else {
-        //     return
-        // }
+        guard let status = conversionInfo["af_status"] as? String else {
+            return
+        }
         
-        // if (firstLaunchFlag == 1) {
+        if (firstLaunchFlag == 1) {
             segDelegate?.onConversionDataSuccess(conversionInfo)
-            // if (status == "Non-organic") {
+            if (status == "Non-organic") {
                 if let mediaSource = conversionInfo["media_source"] , let campaign = conversionInfo["campaign"], let adgroup = conversionInfo["adgroup"]{
                     
                     let campaign: [String: Any] = [
@@ -250,12 +250,10 @@ extension AppsFlyerDestination: AppsFlyerLibDelegate {
                     analytics?.track(name: "Install Attributed", properties: properties)
                     
                 }
-            // } else {
-            //     analytics?.track(name: "Organic Install")
-            // }
-        // } else {
-        // }
-        
+            } else {
+                analytics?.track(name: "Organic Install")
+            }
+        }
     }
     
     public func onConversionDataFail(_ error: Error) {

--- a/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
+++ b/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
@@ -97,6 +97,8 @@ public class AppsFlyerDestination: UIResponder, DestinationPlugin  {
         }
     }
 
+// This is for the Manual Mode !
+// Once calling this function every didBecomeActive start will be called.
     public func startAppsflyerSDK(){
         startAFSDK()
         NotificationCenter.default.addObserver(self, selector: #selector(listenerStartSDK), name: UIApplication.didBecomeActiveNotification, object: nil)
@@ -111,7 +113,7 @@ public class AppsFlyerDestination: UIResponder, DestinationPlugin  {
             isFirstLaunch = false
             return
         }
-        AppsFlyerLib.shared().start()
+        startAFSDK()
     }
     
     public func identify(event: IdentifyEvent) -> IdentifyEvent? {

--- a/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
+++ b/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
@@ -32,7 +32,7 @@ import Foundation
 import UIKit
 import Segment
 import AppsFlyerLib
-//moris
+
 @objc(SEGAppsFlyerDestination)
 public class ObjCSegmentAppsFlyer: NSObject, ObjCPlugin, ObjCPluginShim {
     public func instance() -> EventPlugin { return AppsFlyerDestination() }

--- a/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
+++ b/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
@@ -51,7 +51,7 @@ public class AppsFlyerDestination: UIResponder, DestinationPlugin  {
     private weak var segDLDelegate: DeepLinkDelegate?
 
     private var isFirstLaunch = true
-    private var manualMode: Bool
+    private var manualMode: Bool = false
 
     // MARK: - Initialization
 
@@ -82,6 +82,8 @@ public class AppsFlyerDestination: UIResponder, DestinationPlugin  {
         AppsFlyerLib.shared().appleAppID = settings.appleAppID
         AppsFlyerLib.shared().setPluginInfo(plugin:Plugin.segment, version:"2.0.0", additionalParams:["Segment":"Analytics-Swift","Platform":"iOS"])
         
+        // Commented this in order to let the developer set it as suits them.
+        // It is available by the developer with AppsFlyerLib.shared() on their iOS native code.
         // AppsFlyerLib.shared().waitForATTUserAuthorization(timeoutInterval: 60) //OPTIONAL
         AppsFlyerLib.shared().deepLinkDelegate = self //OPTIONAL
         // AppsFlyerLib.shared().isDebug = true
@@ -91,6 +93,10 @@ public class AppsFlyerDestination: UIResponder, DestinationPlugin  {
         if trackAttributionData ?? false {
             AppsFlyerLib.shared().delegate = self
         }
+
+        // Manual mode is a mode which let's the developer the abillity to start the SDK.
+        // Once setting manualMode=true in the init, the develper should use startAppsflyerSDK method to start the SDK.
+        // Once started the SDK it will be start automatically by the life cycle - didBecomeActiveNotification.
         if (!manualMode){
             startAFSDK()
             NotificationCenter.default.addObserver(self, selector: #selector(listenerStartSDK), name: UIApplication.didBecomeActiveNotification, object: nil)
@@ -151,7 +157,7 @@ public class AppsFlyerDestination: UIResponder, DestinationPlugin  {
     }
     
     public func track(event: TrackEvent) -> TrackEvent? {
-        // Appsflyer
+        // Verify we are not looping an event.
         if(event.event == "Install Attributed" || 
             event.event == "Organic Install" || 
             event.event == "Deep Link Opened" ||

--- a/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
+++ b/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
@@ -140,7 +140,13 @@ public class AppsFlyerDestination: UIResponder, DestinationPlugin  {
     }
     
     public func track(event: TrackEvent) -> TrackEvent? {
-        
+        if(event.event == "Install Attributed" || 
+            event.event == "Organic Install" || 
+            event.event == "Deep Link Opened" ||
+            event.event == "Direct Deep Link" ||
+            event.event == "Deferred Deep Link"){
+                return
+            }
         var properties = event.properties?.dictionaryValue
         
         let revenue: Double? = extractRevenue(key: "revenue", from: properties)

--- a/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
+++ b/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
@@ -145,7 +145,7 @@ public class AppsFlyerDestination: UIResponder, DestinationPlugin  {
             event.event == "Deep Link Opened" ||
             event.event == "Direct Deep Link" ||
             event.event == "Deferred Deep Link"){
-                return
+                return nil
             }
         var properties = event.properties?.dictionaryValue
         

--- a/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
+++ b/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
@@ -32,7 +32,7 @@ import Foundation
 import UIKit
 import Segment
 import AppsFlyerLib
-
+//moris
 @objc(SEGAppsFlyerDestination)
 public class ObjCSegmentAppsFlyer: NSObject, ObjCPlugin, ObjCPluginShim {
     public func instance() -> EventPlugin { return AppsFlyerDestination() }

--- a/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
+++ b/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
@@ -51,7 +51,7 @@ public class AppsFlyerDestination: UIResponder, DestinationPlugin  {
     private weak var segDLDelegate: DeepLinkDelegate?
 
     private var isFirstLaunch = true
-    private var manualMode
+    private var manualMode: Bool
 
     // MARK: - Initialization
 


### PR DESCRIPTION
## This merge request introduces several enhancements and refinements to the Segment plugin for improved compatibility and developer experience with the AppsFlyer SDK
**Note: The changes are listed in the order they were implemented, not by their importance.**

- **Allowing Developer Control Over waitForATTUserAuthorization:**
Commented out the AppsFlyerLib.shared().waitForATTUserAuthorization(timeoutInterval: 60) call to give developers the flexibility to set it as per their needs. This can be controlled through their iOS native code using AppsFlyerLib.shared().

- **Support for Manual Mode Initialization:**
Added manualMode functionality to provide developers control over when the SDK starts. When manualMode is set to true in initialization, developers must use the startAppsflyerSDK method to start the SDK manually. Post-initialization, the SDK will start automatically during the app lifecycle (didBecomeActiveNotification).
This enables developers to update DMA data before SDK initialization, ensuring accurate DMA recording during install conversion. See [here](https://dev.appsflyer.com/hc/docs/ios-send-consent-for-dma-compliance) more info

- **Added userName Field to Identity Record:**
Included userName in the identity record for better user tracking.

- **Preventing Loop in track() Method for Certain Events:**
Modified the track() method to ignore specific events (Install Attributed, Organic Install, Deep Link Opened, Direct Deep Link, and Deferred Deep Link) to duplications caused by the plugin triggering track().

- **Removed  applicationDidBecomeActive Call:**
Removed the applicationDidBecomeActive implementation in favor of subscribing to applicationDidBecomeActive in the update() method, ensuring starting the SDK before the update method.
In the current implementation we could start the Appsflyer SDK before we set the devKey or any other appsflyer propperties.

These updates enhance the plugin's usability, flexibility, and overall developer experience.