### PR TITLE
Update AppsFlyer SDK to 6.17.8 and fix example app build errors

### DIFF
--- a/Example/BasicExample/BasicExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/BasicExample/BasicExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Dynamic",
         "state": {
           "branch": null,
-          "revision": "0cdea50ab90d9bd63645d2d51bcef5850ca4aa9f",
-          "version": "6.14.0"
+          "revision": "cdbcb9a281fcbc2dba4afb8568a849e4c4557176",
+          "version": "6.17.8"
         }
       },
       {

--- a/Example/BasicExample/BasicExample/BasicExampleApp.swift
+++ b/Example/BasicExample/BasicExample/BasicExampleApp.swift
@@ -33,7 +33,7 @@ struct BasicExampleApp: App {
             segDelegate: BasicExampleApp.afDelegate,
             segDLDelegate: BasicExampleApp.afDelegate,
         )
-        BasicExampleApp.analytics?.add(plugin: NewAnalyticsAppsflyerIntegrationApp.appsflyerDest)
+        BasicExampleApp.analytics?.add(plugin: BasicExampleApp.appsflyerDest)
     }
 
     func requestTrackingAuthorization() {

--- a/Example/BasicExample/BasicExample/ContentView.swift
+++ b/Example/BasicExample/BasicExample/ContentView.swift
@@ -13,34 +13,34 @@ struct ContentView: View {
         VStack {
             HStack {
                 Button(action: {
-                    Analytics.main.track(name: "Track")
+                    BasicExampleApp.analytics?.track(name: "Track")
                 }, label: {
                     Text("Track")
                 }).padding(6)
                 Button(action: {
-                    Analytics.main.screen(title: "Screen appeared")
+                    BasicExampleApp.analytics?.screen(title: "Screen appeared")
                 }, label: {
                     Text("Screen")
                 }).padding(6)
             }.padding(8)
             HStack {
                 Button(action: {
-                    Analytics.main.group(groupId: "12345-Group")
-                    Analytics.main.log(message: "Started group")
+                    BasicExampleApp.analytics?.group(groupId: "12345-Group")
+                    BasicExampleApp.analytics?.log(message: "Started group")
                 }, label: {
                     Text("Group")
                 }).padding(6)
                 Button(action: {
-                    Analytics.main.identify(userId: "X-1234567890")
+                    BasicExampleApp.analytics?.identify(userId: "X-1234567890")
                 }, label: {
                     Text("Identify")
                 }).padding(6)
             }.padding(8)
         }.onAppear {
-            Analytics.main.track(name: "onAppear")
+            BasicExampleApp.analytics?.track(name: "onAppear")
             print("Executed Analytics onAppear()")
         }.onDisappear {
-            Analytics.main.track(name: "onDisappear")
+            BasicExampleApp.analytics?.track(name: "onDisappear")
             print("Executed Analytics onDisappear()")
         }
     }

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Dynamic",
         "state": {
           "branch": null,
-          "revision": "9ff9532a55c1c44c3566d192773cdf5d454ea384",
-          "version": "6.17.0"
+          "revision": "cdbcb9a281fcbc2dba4afb8568a849e4c4557176",
+          "version": "6.17.8"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .package(
             name: "AppsFlyerLib-Dynamic",
             url: "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Dynamic",
-            .exact("6.17.0")
+            .exact("6.17.8")
         )
     ],
     targets: [


### PR DESCRIPTION
## Changes
- Update AppsFlyer SDK from 6.17.0 to 6.17.8
- Fix example app build errors:
  - `BasicExampleApp.swift`: Fixed incorrect class reference (`NewAnalyticsAppsflyerIntegrationApp` → `BasicExampleApp`)
  - `ContentView.swift`: Fixed undefined `Analytics.main` → `BasicExampleApp.analytics?`

## Testing
- Built and ran example app on iPhone 17 simulator
- Verified SDK starts correctly (v6.17.8)
- Verified events are sent successfully