### PR TITLE
fix: resolve build errors in BasicExample app

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -22,8 +22,8 @@ jobs:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
+    - uses: actions/checkout@v4
+    - uses: actions/cache@v4
       with:
         path: /Users/runner/Library/Developer/Xcode/DerivedData
         key: ${{ runner.os }}-spm-examples-${{ hashFiles('**/Package.resolved') }}

--- a/Example/BasicExample/BasicExample/BasicExampleApp.swift
+++ b/Example/BasicExample/BasicExample/BasicExampleApp.swift
@@ -33,7 +33,7 @@ struct BasicExampleApp: App {
             segDelegate: BasicExampleApp.afDelegate,
             segDLDelegate: BasicExampleApp.afDelegate,
         )
-        BasicExampleApp.analytics?.add(plugin: NewAnalyticsAppsflyerIntegrationApp.appsflyerDest)
+        BasicExampleApp.analytics?.add(plugin: BasicExampleApp.appsflyerDest)
     }
 
     func requestTrackingAuthorization() {

--- a/Example/BasicExample/BasicExample/ContentView.swift
+++ b/Example/BasicExample/BasicExample/ContentView.swift
@@ -13,34 +13,34 @@ struct ContentView: View {
         VStack {
             HStack {
                 Button(action: {
-                    Analytics.main.track(name: "Track")
+                    BasicExampleApp.analytics?.track(name: "Track")
                 }, label: {
                     Text("Track")
                 }).padding(6)
                 Button(action: {
-                    Analytics.main.screen(title: "Screen appeared")
+                    BasicExampleApp.analytics?.screen(title: "Screen appeared")
                 }, label: {
                     Text("Screen")
                 }).padding(6)
             }.padding(8)
             HStack {
                 Button(action: {
-                    Analytics.main.group(groupId: "12345-Group")
-                    Analytics.main.log(message: "Started group")
+                    BasicExampleApp.analytics?.group(groupId: "12345-Group")
+                    BasicExampleApp.analytics?.log(message: "Started group")
                 }, label: {
                     Text("Group")
                 }).padding(6)
                 Button(action: {
-                    Analytics.main.identify(userId: "X-1234567890")
+                    BasicExampleApp.analytics?.identify(userId: "X-1234567890")
                 }, label: {
                     Text("Identify")
                 }).padding(6)
             }.padding(8)
         }.onAppear {
-            Analytics.main.track(name: "onAppear")
+            BasicExampleApp.analytics?.track(name: "onAppear")
             print("Executed Analytics onAppear()")
         }.onDisappear {
-            Analytics.main.track(name: "onDisappear")
+            BasicExampleApp.analytics?.track(name: "onDisappear")
             print("Executed Analytics onDisappear()")
         }
     }


### PR DESCRIPTION
## Summary
- Fix incorrect type reference `NewAnalyticsAppsflyerIntegrationApp` → `BasicExampleApp` in `BasicExampleApp.swift`
- Replace `Analytics.main` with `BasicExampleApp.analytics?` in `ContentView.swift` (6 occurrences) to match the app's analytics instance setup

## Test plan
- [ ] Verify `xcodebuild -workspace BasicExample.xcworkspace -scheme BasicExample -sdk iphonesimulator` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)