### PR TITLE
chore: bump AppsFlyerLib-Dynamic from 6.17.0 to 6.17.8

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Dynamic",
         "state": {
           "branch": null,
-          "revision": "9ff9532a55c1c44c3566d192773cdf5d454ea384",
-          "version": "6.17.0"
+          "revision": "cdbcb9a281fcbc2dba4afb8568a849e4c4557176",
+          "version": "6.17.8"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .package(
             name: "AppsFlyerLib-Dynamic",
             url: "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Dynamic",
-            .exact("6.17.0")
+            .exact("6.17.8")
         )
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -35,8 +35,11 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "SegmentAppsFlyer",
-            dependencies: ["Segment", "AppsFlyerLib-Dynamic"]),
-        
+            dependencies: ["Segment", "AppsFlyerLib-Dynamic"],
+            linkerSettings: [
+                .linkedFramework("StoreKit")
+            ]),
+
         // TESTS ARE HANDLED VIA THE EXAMPLE APP.
     ]
 )

--- a/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
+++ b/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
@@ -31,6 +31,7 @@
 import Foundation
 import UIKit
 import Segment
+import StoreKit
 import AppsFlyerLib
 
 @objc(SEGAppsFlyerDestination)


### PR DESCRIPTION
## Summary
- Update AppsFlyerLib-Dynamic exact version pin from 6.17.0 to 6.17.8

## Test plan
- [ ] Verify `xcodebuild -workspace BasicExample.xcworkspace -scheme BasicExample -sdk iphonesimulator` succeeds (requires PR #27 merged first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)